### PR TITLE
Fix pythonlint trigger

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -4,9 +4,8 @@ run-name: Python lint
 
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.yml"
+    paths:
+      - "**/*.py"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.

Fix pythonlint trigger.

## What was changed? (変更点)
- `paths: -"**/*.py"` <- paths-ignore: ...
- Directly indicate run trigger when only edited `.py`

## Why was this change needed? (変更理由)
- python lint CI run when no need 
  - e.g. `.gitignore, pyproject.toml, uv.lock`

## How was it tested? (テスト方法)
- GitHub Actions

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass (if applicable)
- [ ] Documentation updated (if needed)