### PR TITLE
Fix return type and typo

### DIFF
--- a/src/sqeleton/op.py
+++ b/src/sqeleton/op.py
@@ -23,7 +23,7 @@ class Operator:
         self.num = num
         self.observableArray = deque()
 
-    def add_oparator(self, s, coef=1.0) -> None:
+    def add_operator(self, s, coef=1.0) -> None:
         """add operator
 
         Args:
@@ -73,7 +73,9 @@ class Operator:
             >>> state = QuantumState(n_qubits)
             >>> observable = Operator(n_qubits)
             >>> observable.add_operator("Z(0), Z(1)", coef=2.0)
-            >>> observable.expectation_value(state)
+            >>> value = observable.expectation_value(state)
+            >>> print(value)
+            [2.+0.j]
         """
         if state.num != self.num:
             print("dimensions error!")

--- a/src/sqeleton/qc.py
+++ b/src/sqeleton/qc.py
@@ -194,7 +194,7 @@ class QuantumCircuit:
         self.gateArray.append(("cnot",control,target))
         return None
     
-    def get_info(self) -> None:
+    def get_info(self) -> str:
         """show circuit information
         (gateType (x,y,z,h,t,rx,ry,rx,cnot), qubit index (target, control), theta (if gate is rotation gate))
 
@@ -203,22 +203,26 @@ class QuantumCircuit:
             >>> circuit.add_X_gate(0)
             >>> circuit.add_RX_gate(0, np.pi)
             >>> circuit.add_CNOT_gate(0, 1)
-            >>> circuit.get_info()
+            >>> s = circuit.get_info()
+            >>> print(s)
             gateType: x , target: 0
             gateType: rx , target: 0 , theta: 3.141592653589793
             gateType: cnot , control: 0 , target: 1
         """
+        s = ""
         if len(self.gateArray) == 0:
             print("No gates.")
             return None
-        for gateInfo in self.gateArray:
+        for i, gateInfo in enumerate(self.gateArray):
             if gateInfo[0] in self._gateBase_1q:
-                print("gateType:", gateInfo[0], ", target:", gateInfo[1])
+                s += "gateType:" + str(gateInfo[0]) + ", target:" + str(gateInfo[1])
             if gateInfo[0] in self._gateRotate_1q:
-                print("gateType:", gateInfo[0], ", target:", gateInfo[1], ", theta:", gateInfo[2])
+                s += "gateType:" + str(gateInfo[0]) + ", target:" + str(gateInfo[1]) + ", theta:" + str(gateInfo[2])
             if gateInfo[0] in self._gateBase_2q:
-                print("gateType:", gateInfo[0], ", control:", gateInfo[1], ", target:", gateInfo[2])
-        return None
+                s += "gateType:" + str(gateInfo[0]) + ", control:" + str(gateInfo[1]) + ", target:" + str(gateInfo[2])
+            if (i < len(self.gateArray)-1):
+                s += "\n"
+        return s
 
     def get_depth(self) -> int:
         """show circuit depth
@@ -228,8 +232,9 @@ class QuantumCircuit:
             >>> circuit.add_X_gate(0)
             >>> circuit.add_RX_gate(0, np.pi)
             >>> circuit.add_CNOT_gate(0, 1)
-            >>> circuit.get_depth()
-            circuit depth : 3
+            >>> depth = circuit.get_depth()
+            >>> print("circuit depth: " + str(depth))
+            circuit depth: 3
         """
         backet = np.zeros(self.num, dtype=int)
         for key, value1, *rest in self.gateArray:

--- a/src/sqeleton/qs.py
+++ b/src/sqeleton/qs.py
@@ -21,43 +21,50 @@ class QuantumState:
             >>> state = QuantumState(2)
         """
         self.num = num
-        self.state = (np.zeros((2**num, 1), dtype=complex))
+        self.dim = 2**num
+        self.state = (np.zeros((self.dim, 1), dtype=complex))
         self.state[0][0] = 1
         self.digit = "0" + str(num) + "b"
 
-    def get_state_vector(self) -> None:
+    def get_state_vector(self) -> str:
         """show state vector
 
         Examples:
             >>> state = QuantumState(2)
-	        >>> state.get_state_vector()
+	        >>> s = state.get_state_vector()
+            >>> print(s)
             |00>: [1.+0.j]
             |01>: [0.+0.j]
             |10>: [0.+0.j]
             |11>: [0.+0.j]
         """
+        s = ""
         for i, vector in enumerate(self.state):
-            print("|" + format(i, self.digit) +">:", end=" ")
-            print(vector)
-        return None
+            s += "|" + format(i, self.digit) +">: " + str(vector)
+            if (i < self.dim-1):
+                s += "\n"
+        return s
     
-    def get_probability_vector(self) -> None:
+    def get_probability_vector(self) -> str:
         """show probability vector
 
         Examples:
             >>> state = QuantumState(2)
-            >>> state.get_probability_vector()
+            >>> s = state.get_probability_vector()
+            >>> print(s)
             |00>: [1.]
             |01>: [0.]
             |10>: [0.]
             |11>: [0.]
         """
+        s = ""
         for i, vector in enumerate(self.state):
-            print("|" + format(i, self.digit) + ">:", end=" ")
-            print(vector.real**2+vector.imag**2)
-        return None
+            s += "|" + format(i, self.digit) + ">: " + str(vector.real**2+vector.imag**2)
+            if (i < self.dim-1):
+                s += "\n"
+        return s
 
-    def sampling(self, count: int) -> None:
+    def sampling(self, count: int) -> str:
         """sampling in the computational basis
 
         Args:
@@ -65,21 +72,24 @@ class QuantumState:
 
         Examples:
             >>> state = QuantumState(2)
-            >>> state.sampling(1000)
+            >>> s = state.sampling(1000)
+            >>> print(s)
             |00>: 1000
             |01>: 0
             |10>: 0
             |11>: 0
         """
+        s = ""
         probability_list = [vector[0].real**2+vector[0].imag**2 for vector in self.state] #note: self.state is 2-dimensional array
-        bitarray = [format(i, self.digit) for i in range(2**self.num)]
+        bitarray = [format(i, self.digit) for i in range(self.dim)]
         result = np.random.choice(bitarray, size=count, replace=True, p=probability_list)
         sampling_result = defaultdict(list)
-        for i in range(2**self.num):
+        for i in range(self.dim):
             sampling_result[format(i, self.digit)] = 0
         for i in range(count):
             sampling_result[result[i]] += 1
-        for key in bitarray:
-            print("|" + key + ">:", end=" ")
-            print(sampling_result[key])
-        return None
+        for i, key in enumerate(bitarray):
+            s += "|" + str(key) + ">: " + str(sampling_result[key])
+            if (i < self.dim-1):
+                s += "\n"
+        return s

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -6,7 +6,7 @@ def test_operator():
         n_qubits = 1
         state = QuantumState(n_qubits)
         observable = Operator(n_qubits)
-        observable.add_oparator("Z(0)")
+        observable.add_operator("Z(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([1], dtype=complex)
@@ -19,7 +19,7 @@ def test_operator():
         circuit.add_X_gate(0)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("Z(0)")
+        observable.add_operator("Z(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([-1], dtype=complex)
@@ -29,7 +29,7 @@ def test_operator():
         n_qubits = 1
         state = QuantumState(n_qubits)
         observable = Operator(n_qubits)
-        observable.add_oparator("Z(0)", coef=-1.0)
+        observable.add_operator("Z(0)", coef=-1.0)
         eval = observable.expectation_value(state)
 
         expected = np.array([-1], dtype=complex)
@@ -43,7 +43,7 @@ def test_operator():
         circuit.add_CNOT_gate(0, 1)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("Z(0), Z(1)")
+        observable.add_operator("Z(0), Z(1)")
         eval = observable.expectation_value(state)
 
         expected = np.array([1], dtype=complex)
@@ -57,7 +57,7 @@ def test_operator():
         circuit.add_CNOT_gate(0, 1)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("Z(0), Z(1)", coef=-1.0)
+        observable.add_operator("Z(0), Z(1)", coef=-1.0)
         eval = observable.expectation_value(state)
 
         expected = np.array([-1], dtype=complex)
@@ -76,7 +76,7 @@ def test_operator():
         circuit.add_H_gate(0)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("X(0)")
+        observable.add_operator("X(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([1], dtype=complex)
@@ -90,7 +90,7 @@ def test_operator():
         circuit.add_Z_gate(0)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("X(0)")
+        observable.add_operator("X(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([-1], dtype=complex)
@@ -107,7 +107,7 @@ def test_operator():
         circuit.add_RZ_gate(0, np.pi/2)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("Y(0)")
+        observable.add_operator("Y(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([1], dtype=complex)
@@ -121,7 +121,7 @@ def test_operator():
         circuit.add_RZ_gate(0, -np.pi/2)
         circuit.update_quantum_state(state)
         observable = Operator(n_qubits)
-        observable.add_oparator("Y(0)")
+        observable.add_operator("Y(0)")
         eval = observable.expectation_value(state)
 
         expected = np.array([-1], dtype=complex)


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.

Fix return type
Fix typo

## What was changed?
- `str` <- `None`

## Why was this change needed?
- usability

## How was it tested?
- Run pytest
